### PR TITLE
#61 - Sort validators table by favorites field

### DIFF
--- a/pages/index.vue
+++ b/pages/index.vue
@@ -454,8 +454,8 @@ export default {
     return {
       perPage: 10,
       currentPage: 1,
-      sortBy: `rank`,
-      sortDesc: false,
+      sortBy: `favorite`,
+      sortDesc: true,
       filter: null,
       filterOn: [],
       totalRows: 1,

--- a/pages/validators.vue
+++ b/pages/validators.vue
@@ -428,8 +428,8 @@ export default {
     return {
       perPage: 10,
       currentPage: 1,
-      sortBy: `rank`,
-      sortDesc: false,
+      sortBy: `favorite`,
+      sortDesc: true,
       filter: null,
       filterOn: [],
       totalRows: 1,


### PR DESCRIPTION
Now Validators table is sorted by favorites. In this way, our favorites validators are showed in first positions.

Issue #61 