### PR TITLE
fix github link over menu

### DIFF
--- a/layouts/default.vue
+++ b/layouts/default.vue
@@ -215,7 +215,7 @@
       title="View source code on GitHub"
       target="_blank"
       ><svg
-        class="github-corner d-none d-md-none d-lg-block"
+        class="github-corner d-none d-md-none d-lg-none d-xl-block"
         width="90"
         height="90"
         viewBox="0 0 250 250"


### PR DESCRIPTION
Fixes #104 

Quick fix hiding the Github icon for lg width and showing only in xl width 